### PR TITLE
Fix for plugins with directories named *.vim

### DIFF
--- a/autoload/ipi.vim
+++ b/autoload/ipi.vim
@@ -135,10 +135,18 @@ function! ipi#load(path, plugin) abort
 	call filter(rtp,'v:val[0:strlen(path)-1] !=# path')
 	let &rtp = pathogen#join(pathogen#uniq(before + rtp + after))
 
+	if filereadable(path.sep.'custom.vim')
+		exec 'source '.fnameescape(path.sep.'custom.vim')
+	endif
+
 	call ipi#source(path.sep.'plugin')
 	call ipi#source(path.sep.'ftdetect')
 	call ipi#source(path.sep.'after'.sep.'plugin')
 	call ipi#source(path.sep.'after'.sep.'ftdetect')
+
+	if filereadable(path.sep.'custom_after.vim')
+		exec 'source '.fnameescape(path.sep.'custom_after.vim')
+	endif
 
 	" execute autocommand VimEnter for known plugins
 	let p = substitute(tolower(a:plugin), '[^a-z]', '', 'g')

--- a/autoload/ipi.vim
+++ b/autoload/ipi.vim
@@ -110,6 +110,8 @@ function! ipi#source(path) abort
 		for f in pathogen#glob(a:path.sep.'*.vim')
 			if filereadable(f)
 				exec 'source '.fnameescape(f)
+      else
+        call ipi#source(f)
 			endif
 		endfor
 	endif


### PR DESCRIPTION
I've been finding ipi very useful but it didn't seem to work for the hammer plugin (https://github.com/robgleeson/hammer.vim).  It seems that this was due to hammer having a directory named hammer.vim inside of its plugin directory.  This is a small change that causes ipi#source to source files it finds in directories named *.vim.
